### PR TITLE
[UPDATE]EndUser新規登録後の遷移先変更

### DIFF
--- a/app/assets/stylesheets/public/daily_reports.scss
+++ b/app/assets/stylesheets/public/daily_reports.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the public/daily_reports controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/public/daily_reports_controller.rb
+++ b/app/controllers/public/daily_reports_controller.rb
@@ -1,0 +1,2 @@
+class Public::DailyReportsController < ApplicationController
+end

--- a/app/controllers/public/registrations_controller.rb
+++ b/app/controllers/public/registrations_controller.rb
@@ -7,6 +7,10 @@ class Public::RegistrationsController < Devise::RegistrationsController
   # before_action :configure_sign_up_params, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
 
+  def after_sign_up_path_for(resource)
+    admin_root_path
+  end
+
   # GET /resource/sign_up
   # def new
   #   super

--- a/app/helpers/public/daily_reports_helper.rb
+++ b/app/helpers/public/daily_reports_helper.rb
@@ -1,0 +1,2 @@
+module Public::DailyReportsHelper
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -5,6 +5,5 @@
 
 #   def initialize(user)
 #     end_user ||= EndUser.new
-  
 #   end
 # end

--- a/app/models/daily_report.rb
+++ b/app/models/daily_report.rb
@@ -1,0 +1,2 @@
+class DailyReport < ApplicationRecord
+end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,3 +1,3 @@
 class Role < ApplicationRecord
- 
+
 end

--- a/app/views/public/daily_reports/new.html.erb
+++ b/app/views/public/daily_reports/new.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "ログアウト", destroy_end_user_session _path, method: :destroy %>

--- a/app/views/public/sessions/new.html.erb
+++ b/app/views/public/sessions/new.html.erb
@@ -2,8 +2,8 @@
 
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <%= f.label :name %><br />
+    <%= f.text_field :name, autofocus: true, autocomplete: "name" %>
   </div>
 
   <div class="field">

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -46,7 +46,7 @@ Devise.setup do |config|
   # session. If you need permissions, you should implement that in a before filter.
   # You can also supply a hash where the value is a boolean determining whether
   # or not authentication should be aborted when the value is not present.
-  # config.authentication_keys = [:email]
+  config.authentication_keys = [:name]
 
   # Configure parameters from the request object used for authentication. Each entry
   # given should be a request method and it will automatically be passed to the

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,10 @@ Rails.application.routes.draw do
     sessions: "public/sessions"
   }
   
+  scope module: :public do
+    resources :daily_reports, only: [:new, :create]
+  end
+  
   # 管理者
   devise_for :admins, skip: [:registrations, :passwords], controllers: {
     sessions: "admin/sessions"

--- a/db/migrate/20220506070649_create_daily_reports.rb
+++ b/db/migrate/20220506070649_create_daily_reports.rb
@@ -1,0 +1,15 @@
+class CreateDailyReports < ActiveRecord::Migration[6.1]
+  def change
+    create_table :daily_reports do |t|
+
+      t.integer "end_user_id", null: false
+      t.integer "company_id", null: false
+      t.integer "construction_id", null: false
+      t.integer "car_id", null: false
+      t.integer "material_id", null: false
+      
+
+      t.timestamps
+    end
+  end
+end

--- a/test/controllers/public/daily_reports_controller_test.rb
+++ b/test/controllers/public/daily_reports_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Public::DailyReportsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/daily_reports.yml
+++ b/test/fixtures/daily_reports.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/daily_report_test.rb
+++ b/test/models/daily_report_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class DailyReportTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
「追加」
・EndUser新規登録後の遷移先をadmin_root_pathへ変更
・daily_reportモデル、コントローラの作成(データベースのカラム未作成）
・EndUserのログイン　e-mailから名前ログインに変更